### PR TITLE
fix-ClickableText - Unique IA Responses

### DIFF
--- a/apps/masterbots.ai/components/chat-clickable-text.tsx
+++ b/apps/masterbots.ai/components/chat-clickable-text.tsx
@@ -8,18 +8,28 @@ export function ClickableText({
   sendMessageFromResponse?: (message: string) => void
 }) {
   const fullText: string = extractTextFromReactNode(children)
-  // * previous regexPattern = isListItem ? /.*?[:.,](?:\s|$)/ : /.*?[.](?:\s|$)/
-  // ? regExp breaks on the first : or . or , and return the first part of the matching string.
-  const regexPattern = /(.*?)([:.,])(?:\s|$)/g
-  const match = fullText.match(regexPattern)
-  const clickableText = match ? match[0] : ''
-  const restText = match ? fullText.slice(match[0].length) : ''
+  // ? This regex matches any variation of the unique key phrases followed by a colon and then captures the following sentence.
+  const uniquePattern =
+    /(?:Unique insight|Unique Tip|Unique, lesser-known solution):\s*([^.:]+[.])/i
+
+  const generalPattern = /(.*?)([:.,])(?:\s|$)/g
+  // First, check for the UNIQUE pattern
+  const uniqueMatch = fullText.match(uniquePattern)
+  let clickableText = uniqueMatch ? uniqueMatch[1] : ''
+  let restText = uniqueMatch
+    ? fullText.slice(fullText.indexOf(clickableText) + clickableText.length)
+    : fullText
+
+  // If the UNIQUE pattern isn't found, use the general pattern
+  if (!uniqueMatch) {
+    const match = fullText.match(generalPattern)
+    clickableText = match ? match[0] : ''
+    restText = match ? fullText.slice(match[0].length) : ''
+  }
 
   const handleClick = () => {
-    if (sendMessageFromResponse && match) {
-      sendMessageFromResponse(
-        clickableText.replace(/(:|\.|\,)\s*$/, '').replace(/•\s/g, '')
-      )
+    if (sendMessageFromResponse && clickableText) {
+      sendMessageFromResponse(clickableText.replace(/(:|\.|\,)\s*$/, ''))
     }
   }
 
@@ -30,7 +40,7 @@ export function ClickableText({
   return (
     <>
       <span
-        className="text-link cursor-pointer hover:underline"
+        className="cursor-pointer text-link hover:underline"
         onClick={handleClick}
       >
         {clickableText}


### PR DESCRIPTION
## PR Request

### ClickableText - Unique IA Responses - [Case](https://trello.com/c/pWXOkHc8/93-clickable-phrase-stops-at-commas-they-should-be-either-dots-or-colons)

#### Bug Fixes

Fixed an issue where only the word "UNIQUE" was being made clickable instead of the entire sentence following the "UNIQUE, LESSER-KNOWN SOLUTION:" pattern and addressed edge cases where the clickable text would not include the full sentence due to the presence of certain punctuation marks.

#### Changelog
- Modified the regular expression (uniquePattern) to correctly identify and make clickable the sentences that follow specific key phrases: "Unique insight", "Unique Tip", "Unique, lesser-known solution".
- Made uniquePattern regex case-insensitive to match key phrases regardless of how they are capitalized.
- Removed the isListItem prop from the logic as it was no longer used in determining the clickable text.
- Cleaned up the handleClick function to ensure that it trims the clickable text and removes any trailing punctuation before passing it to the sendMessageFromResponse callback.

Preview: 

[MASTERB- 2024-02-28 a la(s) 11.06.48.zip](https://github.com/bitcashorg/masterbots/files/14437858/MASTERB-.2024-02-28.a.la.s.11.06.48.zip)
[MASTERB2 2024-02-28 a la(s) 11.07.19.zip](https://github.com/bitcashorg/masterbots/files/14437859/MASTERB2.2024-02-28.a.la.s.11.07.19.zip)




