### PR TITLE
devops: use foo-software/lighthouse-check-action

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -31,12 +31,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Audit preview URL with Lighthouse
         id: lighthouse_audit
-        uses: treosh/lighthouse-ci-action@v3
+        uses: foo-software/lighthouse-check-action@master
         with:
           urls: |
             "https://${{ steps.vercel_preview_url.outputs.preview_url }}"
-          uploadArtifacts: true
-          temporaryPublicStorage: true
       - name: Format lighthouse score
         id: format_lighthouse_score
         uses: actions/github-script@v7.0.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the tool used for running Lighthouse CI checks to improve performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->