### PR TITLE
Hotfix: Show first question & answer in thread list

### DIFF
--- a/apps/masterbots.ai/components/browse-chat-message-list.tsx
+++ b/apps/masterbots.ai/components/browse-chat-message-list.tsx
@@ -35,8 +35,10 @@ export function BrowseChatMessageList({
         <ChatAccordion
           defaultState
           key={key}
+          isOpen={key !== 0}
+          disabled={key === 0}
           contentClass={`!border-l-[transparent] ${key === pairs.length - 1 ? '!border-b-[transparent]' : ''}`}
-          triggerClass={`dark:border-b-mirage border-b-gray-300 py-[0.625rem] px-[47px] gap-4 ${key === 0 && !isThread ? 'hidden' : ''}`}
+          triggerClass="dark:border-b-mirage border-b-gray-300 py-[0.625rem] px-[47px] gap-4"
           arrowClass="mt-[0.625rem] right-[calc(47px-1rem)] translate-x-[50%]"
         >
           {/* Thread Title */}

--- a/apps/masterbots.ai/components/chat/chat-accordion.tsx
+++ b/apps/masterbots.ai/components/chat/chat-accordion.tsx
@@ -17,6 +17,7 @@ export const ChatAccordion = ({
   arrowClass,
   handleOpen,
   handleTrigger,
+  disabled = false,
   ...props
 }: {
   className?: string
@@ -30,6 +31,7 @@ export const ChatAccordion = ({
   handleTrigger?: () => void
   handleOpen?: () => void
   thread?: Thread | null
+  disabled?: boolean
 }) => {
   const { activeThread, setActiveThread, setIsNewResponse, isNewResponse } =
     useThread()
@@ -82,7 +84,9 @@ export const ChatAccordion = ({
     <div className={className || ''} {...props}>
       <button
         data-state={open ? 'open' : 'closed'}
-        onClick={toggle}
+        onClick={() => {
+          if (!disabled) toggle()
+        }}
         className={`flex flex-1 justify-start flex-col relative
         transition-all ease-in-out duration-200
         border-transparent border
@@ -104,7 +108,7 @@ export const ChatAccordion = ({
                 }
               }
             : {})}
-          className={`${open ? '' : '-rotate-90'} absolute -right-2 size-4 shrink-0 mr-4 transition-transform duration-200 ${arrowClass || ''}`}
+          className={`${open ? '' : '-rotate-90'} absolute -right-2 size-4 shrink-0 mr-4 transition-transform duration-200 ${arrowClass || ''} ${disabled ? 'hidden' : ''}`}
         />
       </button>
       <div

--- a/apps/masterbots.ai/components/chat/chat-accordion.tsx
+++ b/apps/masterbots.ai/components/chat/chat-accordion.tsx
@@ -85,7 +85,9 @@ export const ChatAccordion = ({
       <button
         data-state={open ? 'open' : 'closed'}
         onClick={() => {
-          if (!disabled) toggle()
+          if (!disabled) {
+            toggle()
+          }
         }}
         className={`flex flex-1 justify-start flex-col relative
         transition-all ease-in-out duration-200


### PR DESCRIPTION


<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug where the first question and answer in the thread list were not shown. It introduces a 'disabled' prop to the ChatAccordion component to manage the toggle functionality and visibility of the arrow icon, ensuring the first ChatAccordion is open and visible.

- **Bug Fixes**:
    - Fixed an issue where the first question and answer in the thread list were not displayed by ensuring the first ChatAccordion is open and not hidden.
- **Enhancements**:
    - Added a 'disabled' prop to the ChatAccordion component to control the toggle functionality and visibility of the arrow icon.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new properties `isOpen` and `disabled` to enhance the interactivity of chat message lists and accordions.
	- Improved visual cues and accessibility by allowing the accordion to be disabled based on specific conditions.

- **Bug Fixes**
	- Resolved issues with the conditional rendering and interaction of the accordion component based on the item's position in the list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->