### PR TITLE
[masterbots.ai] fix: restore desktop navigation link - browse section

### DIFF
--- a/apps/masterbots.ai/components/layout/header/header.tsx
+++ b/apps/masterbots.ai/components/layout/header/header.tsx
@@ -21,6 +21,8 @@ export function Header() {
         <div className="hidden lg:flex lg:items-center">
           <IconSeparator className="size-6 text-muted-foreground/50" />
           <HeaderLink href="/c" text="Chat" />
+          <HeaderLink href="/b" text="Browse" />
+
           
           {appConfig.devMode && (
             <>


### PR DESCRIPTION

## OPEN PR

### PR Reason: 

- While running tests on the current https://dev.masterbots.ai/, I noticed it was impossible to navigate back to `/b` as the navigation link to `/b` was removed. 

### Fix: 

- Including back the  ```<HeaderLink href="/b" text="Browse" />```

## Images: 

### Old: 
![Screenshot 2024-11-09 at 11 26 23 AM](https://github.com/user-attachments/assets/19c1c9f0-ae9c-4ea6-9c7a-3dc583a14617)

### Fixed: 

![Screenshot 2024-11-09 at 11 35 22 AM](https://github.com/user-attachments/assets/9b3af42b-5084-4368-bbec-6b9c9a3db348)

NOTE: The new mobile sidebar includes all the navigation links/routes and seems to be ok

@coderabbitai , don't check this one please, no need for this one 

