### PR TITLE
fix: hasura thread delete + user dup permissions

### DIFF
--- a/apps/hasura/metadata/databases/masterbots/tables/public_user.yaml
+++ b/apps/hasura/metadata/databases/masterbots/tables/public_user.yaml
@@ -141,23 +141,6 @@ select_permissions:
         - username
       filter: {}
     comment: ""
-  - role: moderator
-    permission:
-      columns:
-        - date_joined
-        - email
-        - get_free_month
-        - is_blocked
-        - is_verified
-        - last_login
-        - pro_user_subscription_id
-        - profile_picture
-        - role
-        - slug
-        - user_id
-        - username
-      filter: {}
-    comment: ""
   - role: user
     permission:
       columns:

--- a/apps/masterbots.ai/services/hasura/hasura.service.ts
+++ b/apps/masterbots.ai/services/hasura/hasura.service.ts
@@ -866,9 +866,12 @@ export async function deleteThread({
       deleteThread: {
         __args: {
           where: { threadId: { _eq: threadId }, userId: { _eq: userId } }
-        }
-      },
-      affected_rows: true
+        },
+        returning: {
+          threadId: true
+        },
+        affectedRows: true
+      }
     })
 
     return { success: true }


### PR DESCRIPTION
## Summary by Sourcery

Fix thread deletion functionality and remove duplicate permissions for the 'moderator' role in Hasura metadata.

Bug Fixes:
- Fix the deletion of threads by ensuring the correct return of affected rows and thread IDs.

Enhancements:
- Remove duplicate permissions for the 'moderator' role in the Hasura metadata configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added new array relationships for the user table, enhancing data connections.
	- Improved user retrieval with error handling for non-existent users.
	- Updated thread deletion process to return the deleted thread ID.
	- Enhanced JWT authentication checks for thread-related queries.

- **Bug Fixes**
	- Refined error handling across several service functions for better logging and responses.

- **Documentation**
	- Updated permissions for user roles to reflect changes in allowed columns and filter conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->