### PR TITLE
fix: add extra rules to clickable styles

### DIFF
--- a/apps/masterbots.ai/app/globals.css
+++ b/apps/masterbots.ai/app/globals.css
@@ -457,40 +457,46 @@
     background-image: var(--background-public-gradient);
   }
   
-  /* clickable list heading color */
-  .clickable-list-heading {
-    color: #db9eff !important;
-    cursor: pointer;
-    transition: color 0.2s ease;
-  }
-  
-  .clickable-list-heading:hover {
-    color: #c663ff !important;
-    text-decoration: underline;
-  }
-  
-  /* Dark mode support */
-  .dark .clickable-list-heading {
-    color: #db9eff;
-  }
-  
-  .dark .clickable-list-heading:hover {
-    color: #c663ff;
-  }
+/* Base styles for clickable-list-heading */
+.clickable-list-heading {
+  pointer-events: none; /* Disables click events on the parent */
+}
+
+/* Enable clicks only on strong elements */
+.clickable-list-heading strong {
+  color: #db9eff !important;
+  transition: color 0.2s ease;
+  pointer-events: auto; /* Re-enables click events specifically for strong elements */
+  cursor: pointer;
+}
+
+.clickable-list-heading strong:hover {
+  color: #c663ff !important;
+  text-decoration: underline;
+}
+
+/* Dark mode support */
+.dark .clickable-list-heading strong {
+  color: #db9eff;
+}
+
+.dark .clickable-list-heading strong:hover {
+  color: #c663ff;
+}
 
 /* clickable headings color */
   .clickable-heading{
-    color: #db9eff !important;
+    color: #d081fd !important;
     cursor: pointer;
     transition: color 0.2s ease;
   }
   .clickable-heading:hover{
-    color: #c663ff !important;
+    color: #b159e4 !important;
   }
   .dark .clickable-heading{
-    color: #db9eff;
+    color: #d081fd;
   }
   .dark .clickable-heading:hover{
-    color: #c663ff;
+    color: #b159e4;
   }
 }

--- a/apps/masterbots.ai/components/routes/chat/chat-message.tsx
+++ b/apps/masterbots.ai/components/routes/chat/chat-message.tsx
@@ -185,20 +185,19 @@ export function ChatMessage({
             // Process strong/emphasis nodes.
             strong({ children }) {
               return <strong
-              className='clickable-list-heading'
               >{preprocessChildren(children)}</strong>
             },
             // List handling.
             ul({ children }) {
               return (
-                <ul className="ml-2 space-y-2 list-disc nested-list">
+                <ul className="ml-2 space-y-2 list-disc">
                   {children}
                 </ul>
               )
             },
             ol({ children }) {
               return (
-                <ol className="ml-2 space-y-2 list-decimal nested-list">
+                <ol className="ml-2 space-y-2 list-decimal">
                   {children}
                 </ol>
               )
@@ -220,6 +219,7 @@ export function ChatMessage({
                   className={cn(
                     'ml-4',
                     hasNestedList && 'mt-2',
+                    'clickable-list-heading'
                   )}
                   onClick={() => handleClickableClick(text)}
                 >


### PR DESCRIPTION
## Summary by Sourcery

Restrict click events to strong elements within clickable-list-heading and update the color scheme for clickable-heading.

Bug Fixes:
- Fix clickable styles by restricting click events to strong elements within clickable-list-heading, ensuring proper interaction.

Enhancements:
- Update color scheme for clickable-heading and its hover state for both light and dark modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced clickable element styling: now, only emphasized text within headings is interactive, providing clearer user interactions.
  - Updated color schemes and hover effects for clickable text, including tailored support for dark mode.
  - Refined the display of clickable elements in chat messages for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->