### PR TITLE
feat: refresh attachment link

### DIFF
--- a/apps/masterbots.ai/app/api/cron/refresh-attachment-links/route.ts
+++ b/apps/masterbots.ai/app/api/cron/refresh-attachment-links/route.ts
@@ -1,0 +1,23 @@
+import { refreshAttachmentLinks } from '@/lib/cron/refresh-attachment-links'
+import { type NextRequest, NextResponse } from 'next/server'
+
+export async function GET(request: NextRequest) {
+	try {
+		const result = await refreshAttachmentLinks()
+
+		return NextResponse.json({
+			success: true,
+			message: 'Attachment links refreshed successfully',
+			...result,
+		})
+	} catch (error) {
+		console.error('Error refreshing attachment links:', error)
+		return NextResponse.json(
+			{
+				success: false,
+				error: error instanceof Error ? error.message : 'Unknown error',
+			},
+			{ status: 500 },
+		)
+	}
+}

--- a/apps/masterbots.ai/app/api/generate-images/route.ts
+++ b/apps/masterbots.ai/app/api/generate-images/route.ts
@@ -10,6 +10,11 @@ import OpenAI from 'openai'
 const TIMEOUT_MILLIS = 2 * 60 * 1000
 
 /**
+ * Export maxDuration for Vercel serverless function timeout
+ */
+export const maxDuration = 120 // seconds
+
+/**
  * Default image size for OpenAI models
  */
 const DEFAULT_IMAGE_SIZE = '1024x1024'

--- a/apps/masterbots.ai/app/api/generate-images/route.ts
+++ b/apps/masterbots.ai/app/api/generate-images/route.ts
@@ -5,9 +5,9 @@ import { type NextRequest, NextResponse } from 'next/server'
 import OpenAI from 'openai'
 
 /**
- * Maximum execution time (55 seconds, slightly less than the Edge runtime limit)
+ * Maximum execution time (2 minutes)
  */
-const TIMEOUT_MILLIS = 55 * 1000
+const TIMEOUT_MILLIS = 2 * 60 * 1000
 
 /**
  * Default image size for OpenAI models

--- a/apps/masterbots.ai/components/routes/browse/browse-list.tsx
+++ b/apps/masterbots.ai/components/routes/browse/browse-list.tsx
@@ -32,7 +32,7 @@ import { useSonner } from '@/lib/hooks/useSonner'
 import { searchThreadContent } from '@/lib/search'
 import { getOpeningActiveThreadHelper } from '@/lib/threads'
 import { getBrowseThreads } from '@/services/hasura'
-import { debounce, isEqual } from 'lodash'
+import { debounce, isEqual, uniqBy } from 'lodash'
 import { appConfig } from 'mb-env'
 import type { Chatbot, Thread } from 'mb-genql'
 import { useSession } from 'next-auth/react'
@@ -69,6 +69,7 @@ export default function BrowseList({
 	} = useSidebar()
 	const prevSelectedCategories = React.useRef<number[]>(selectedCategories)
 	const prevSelectedChatbots = React.useRef<number[]>(selectedChatbots)
+	const searchTimeoutRef = React.useRef<NodeJS.Timeout | null>(null)
 	const { data: session } = useSession()
 	const { customSonner } = useSonner()
 	const userId = session?.user?.id
@@ -82,10 +83,12 @@ export default function BrowseList({
 		categoriesId,
 		chatbotsId,
 		keyword,
+		offset = 0,
 	}: {
 		categoriesId: number[]
 		chatbotsId: number[]
 		keyword: string
+		offset?: number
 	}) => {
 		setLoading(true) // ? Setting loading before fetch
 		try {
@@ -106,9 +109,16 @@ export default function BrowseList({
 							...(userId ? { followedUserId: userId } : {}),
 						}),
 				limit: PAGE_SIZE,
+				offset,
 			})
-			setThreadState(threads)
-			setFilteredThreads(threads)
+			setThreadState((prevState: Thread[]) =>
+				uniqBy([...prevState, ...threads], 'threadId'),
+			)
+			setFilteredThreads((prevState: Thread[]) =>
+				uniqBy([...prevState, ...threads], 'threadId').filter(
+					(thread: Thread) => searchThreadContent(thread, keyword),
+				),
+			)
 			setCount(count)
 			setHasInitialized(true) // ? Setting hasInitialized after fetch preventing NoResults from showing
 		} catch (error) {
@@ -118,33 +128,42 @@ export default function BrowseList({
 		}
 	}
 
-	const verifyKeyword = () => {
+	// biome-ignore lint/correctness/useExhaustiveDependencies: No need to track fetchThreads in the dependency array
+	const verifyKeyword = React.useCallback(() => {
+		// Clear previous timeout
+		if (searchTimeoutRef.current) {
+			clearTimeout(searchTimeoutRef.current)
+		}
+
 		if (!keyword) {
 			setFilteredThreads(threads)
 		} else {
-			debounce(() => {
-				// Use our searchThreadContent function instead of just title search
-				setFilteredThreads(
-					threads.filter((thread: Thread) =>
-						searchThreadContent(thread, keyword),
-					),
-				)
-			}, 230)()
+			// Set new timeout for debouncing
+			searchTimeoutRef.current = setTimeout(async () => {
+				await fetchThreads({
+					categoriesId: selectedCategories,
+					chatbotsId: selectedChatbots,
+					keyword,
+				})
+			}, 440)
 		}
-	}
+	}, [keyword, threads, selectedChatbots, selectedCategories])
 
 	const loadMore = async () => {
-		console.log('🟡 Loading More Content')
+		// if (threads.length >= countState) return
+		console.log('🟡 Loading More Content', {
+			countState,
+			threads,
+			filteredThreads,
+		})
 		setLoading(true)
 
-		const { threads: moreThreads, count } = await getBrowseThreads({
+		await fetchThreads({
 			categoriesId: selectedCategories,
+			chatbotsId: selectedChatbots,
+			keyword,
 			offset: threads.length,
-			limit: PAGE_SIZE,
 		})
-
-		setThreadState((prevState) => [...prevState, ...moreThreads])
-		setCount(count)
 		setLoading(false)
 	}
 
@@ -232,7 +251,16 @@ export default function BrowseList({
 
 		verifyKeyword()
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [keyword, threads])
+	}, [keyword])
+
+	// Cleanup timeout on unmount
+	useEffect(() => {
+		return () => {
+			if (searchTimeoutRef.current) {
+				clearTimeout(searchTimeoutRef.current)
+			}
+		}
+	}, [])
 
 	if (loading && threads.length === 0) {
 		return <BrowseListSkeleton count={5} />

--- a/apps/masterbots.ai/instrumentation-client.ts
+++ b/apps/masterbots.ai/instrumentation-client.ts
@@ -22,7 +22,7 @@ Sentry.init({
 	replaysOnErrorSampleRate: 1.0,
 
 	// Setting this option to true will print useful information to the console while you're setting up Sentry.
-	debug: false,
+	debug: process.env.NEXT_PUBLIC_APP_ENV !== 'prod',
 })
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/apps/masterbots.ai/lib/cron/index.ts
+++ b/apps/masterbots.ai/lib/cron/index.ts
@@ -1,0 +1,1 @@
+export { refreshAttachmentLinks } from './refresh-attachment-links'

--- a/apps/masterbots.ai/lib/cron/refresh-attachment-links.ts
+++ b/apps/masterbots.ai/lib/cron/refresh-attachment-links.ts
@@ -1,0 +1,206 @@
+import type { FileAttachment } from '@/lib/hooks/use-chat-attachments'
+import type { ThreadMetadata } from '@/lib/hooks/use-indexed-db'
+import { Storage } from '@google-cloud/storage'
+import { eq, isNotNull, sql } from 'drizzle-orm'
+import { db, thread } from 'mb-drizzle'
+import { appConfig } from 'mb-env'
+import pLimit from 'p-limit'
+
+const EXPIRATION_BUFFER_MS = 1000 * 60 * 15 // 15 minutes before expiry
+const NEW_EXPIRY_DURATION_MS = 1000 * 60 * 60 * 24 * 7 // 7 days
+const CONCURRENT_LIMIT = 4 // Process 4 threads concurrently
+const BUCKET_KEY_PREFIX = 'attachments/' // Configurable bucket key prefix
+
+interface ProcessResult {
+	threadId: string
+	slug: string
+	attachmentsRefreshed: number
+	errors: string[]
+}
+
+export async function refreshAttachmentLinks() {
+	console.log('Starting attachment link refresh job...')
+
+	const storage = new Storage({
+		projectId: appConfig.features.storageProjectId,
+		credentials: {
+			client_email: appConfig.features.storageClientEmail,
+			private_key: appConfig.features.storageSecretAccessKey,
+		},
+	})
+	const bucket = storage.bucket(appConfig.features.storageBucketName)
+
+	// Get all threads that have metadata with attachments that have expiry dates
+	const threadsWithAttachments = await db
+		.select({
+			threadId: thread.threadId,
+			slug: thread.slug,
+			metadata: thread.metadata,
+		})
+		.from(thread)
+		.where(
+			sql`${thread.metadata}::jsonb ? 'attachments' AND 
+          jsonb_array_length(${thread.metadata}::jsonb->'attachments') > 0 AND
+          EXISTS (
+            SELECT 1 FROM jsonb_array_elements(${thread.metadata}::jsonb->'attachments') AS attachment
+            WHERE attachment ? 'expires' 
+            AND (attachment->>'expires')::timestamptz <= (NOW() + INTERVAL '${EXPIRATION_BUFFER_MS} milliseconds')
+          )`,
+		)
+
+	console.log(
+		`Found ${threadsWithAttachments.length} threads with metadata to update`,
+	)
+
+	// Set up concurrent processing with limit
+	const limit = pLimit(CONCURRENT_LIMIT)
+
+	// Process threads concurrently with batching
+	const results = await Promise.allSettled(
+		threadsWithAttachments.map((threadRecord) =>
+			limit(() => processThread(threadRecord, bucket)),
+		),
+	)
+
+	// Aggregate results
+	let threadsUpdated = 0
+	let attachmentsRefreshed = 0
+	const errors: string[] = []
+
+	for (const result of results) {
+		if (result.status === 'fulfilled') {
+			const processResult = result.value
+			if (processResult.attachmentsRefreshed > 0) {
+				threadsUpdated++
+			}
+			attachmentsRefreshed += processResult.attachmentsRefreshed
+			errors.push(...processResult.errors)
+		} else {
+			errors.push(`Promise rejected: ${result.reason}`)
+		}
+	}
+
+	const finalResult = {
+		threadsProcessed: threadsWithAttachments.length,
+		threadsUpdated,
+		attachmentsRefreshed,
+		errors,
+	}
+
+	console.log('Attachment link refresh job completed:', finalResult)
+
+	return finalResult
+}
+
+async function processThread(
+	threadRecord: { threadId: string; slug: string; metadata: any },
+	bucket: any,
+): Promise<ProcessResult> {
+	const result: ProcessResult = {
+		threadId: threadRecord.threadId,
+		slug: threadRecord.slug,
+		attachmentsRefreshed: 0,
+		errors: [],
+	}
+
+	try {
+		const metadata = threadRecord.metadata as ThreadMetadata | null
+		if (!metadata?.attachments?.length) return result
+
+		const attachments = metadata.attachments as FileAttachment[]
+		const updatedAttachments = [...attachments] // Create a copy for updates
+		let hasUpdates = false
+
+		for (let i = 0; i < updatedAttachments.length; i++) {
+			const attachment = updatedAttachments[i]
+
+			try {
+				if (!attachment.expires) continue
+
+				const expiry = new Date(attachment.expires).getTime()
+				const now = Date.now()
+
+				// Check if the attachment link is expiring soon
+				if (expiry - now < EXPIRATION_BUFFER_MS) {
+					console.log(
+						`Refreshing expiring link for attachment: ${attachment.name} in thread: ${threadRecord.slug}`,
+					)
+
+					const bucketKey = attachment.content as string
+
+					if (
+						typeof bucketKey !== 'string' ||
+						!bucketKey.startsWith(BUCKET_KEY_PREFIX)
+					) {
+						const errorMsg = `Invalid bucket key for attachment ${attachment.id}: ${bucketKey}`
+						console.warn(errorMsg)
+						result.errors.push(errorMsg)
+						continue
+					}
+
+					const file = bucket.file(bucketKey)
+
+					// Check if file exists in bucket
+					const [exists] = await file.exists()
+					if (!exists) {
+						const errorMsg = `File not found in bucket: ${bucketKey}`
+						console.warn(errorMsg)
+						result.errors.push(errorMsg)
+						continue
+					}
+
+					// Generate new signed URL
+					const newExpiry = now + NEW_EXPIRY_DURATION_MS
+					const [signedUrl] = await file.getSignedUrl({
+						version: 'v4',
+						action: 'read',
+						expires: newExpiry,
+					})
+
+					// Update attachment with new URL and expiry
+					updatedAttachments[i] = {
+						...attachment,
+						url: signedUrl,
+						expires: new Date(newExpiry).toISOString(),
+					}
+
+					hasUpdates = true
+					result.attachmentsRefreshed++
+
+					console.log(
+						`Successfully refreshed link for attachment: ${attachment.name}`,
+					)
+				}
+			} catch (attachmentError) {
+				const errorMsg = `Error processing attachment ${attachment.id} in thread ${threadRecord.threadId}: ${attachmentError instanceof Error ? attachmentError.message : 'Unknown error'}`
+				console.error(errorMsg)
+				result.errors.push(errorMsg)
+			}
+		}
+
+		// Update the thread in a transaction if any attachments were refreshed
+		if (hasUpdates) {
+			await db.transaction(async (tx) => {
+				await tx
+					.update(thread)
+					.set({
+						metadata: {
+							...metadata,
+							attachments: updatedAttachments,
+						},
+					})
+					.where(eq(thread.threadId, threadRecord.threadId))
+			})
+
+			console.log(
+				`Updated thread ${threadRecord.slug} with ${result.attachmentsRefreshed} refreshed attachment links`,
+			)
+		}
+	} catch (threadError) {
+		const errorMsg = `Error processing thread ${threadRecord.threadId}: ${threadError instanceof Error ? threadError.message : 'Unknown error'}`
+		console.error(errorMsg)
+		result.errors.push(errorMsg)
+	}
+
+	return result
+}

--- a/apps/masterbots.ai/lib/hooks/use-chat-attachments.ts
+++ b/apps/masterbots.ai/lib/hooks/use-chat-attachments.ts
@@ -57,7 +57,7 @@ export function useFileAttachments(
 	},
 ] {
 	const { data: session } = useSession()
-	const { activeThread } = useThread()
+	const { activeThread, loadingState } = useThread()
 	const dbKeys = getUserIndexedDBKeys(session?.user?.id)
 	const { mounted, ...indexedDBActions } = useIndexedDB(dbKeys)
 	const [state, setState] = useSetState<{
@@ -73,7 +73,7 @@ export function useFileAttachments(
 		loading,
 		error,
 	} = useAsync(async () => {
-		if (!mounted || !session?.user) {
+		if (!mounted || !session?.user || (activeThread && loadingState)) {
 			return (activeThread?.metadata?.attachments || []) as IndexedDBItem[]
 		}
 
@@ -103,7 +103,7 @@ export function useFileAttachments(
 
 		currentRequestId.current = null
 		return indexedDBAttachments
-	}, [session?.user, mounted, activeThread?.metadata?.attachments])
+	}, [session?.user, mounted, activeThread, loadingState])
 
 	const { customSonner } = useSonner()
 	const { selectedModel } = useModel()

--- a/apps/masterbots.ai/lib/hooks/use-indexed-db.ts
+++ b/apps/masterbots.ai/lib/hooks/use-indexed-db.ts
@@ -206,15 +206,14 @@ export function useIndexedDB({
 				}
 
 				// Filter out attachments that are currently being processed or already processed
-				const attachmentsToProcess = (
-					newAttachments as FileAttachment[]
-				).filter(
-					(attachment) =>
-						attachment.messageIds.length !==
-							currentUserMetadata?.find((att) => att.id === attachment.id)
-								?.messageIds.length ||
-						(!processingAttachmentsRef.current.has(attachment.id) &&
-							!processedAttachmentIds.includes(attachment.id)),
+				const filterAttachments = (attachment: FileAttachment) =>
+					attachment.messageIds.length !==
+						currentUserMetadata?.find((att) => att.id === attachment.id)
+							?.messageIds.length ||
+					(!processingAttachmentsRef.current.has(attachment.id) &&
+						!processedAttachmentIds.includes(attachment.id))
+				let attachmentsToProcess = (newAttachments as FileAttachment[]).filter(
+					filterAttachments,
 				)
 
 				if (attachmentsToProcess.length === 0) {
@@ -325,19 +324,87 @@ export function useIndexedDB({
 					]
 					setProcessedAttachmentIds(updatedProcessedIds)
 
-					const messagesIds = newAttachments.flatMap(
+					// * Creating a new version of attachments to process for metadata update
+					// * This is to ensure that we only update the thread metadata with the new attachments metadata refs
+					attachmentsToProcess = (newAttachments as FileAttachment[]).filter(
+						filterAttachments,
+					)
+					const messagesIds = attachmentsToProcess.flatMap(
 						(att) => (att as FileAttachment).messageIds,
 					)
-					const metadataUpdateResults = await updateThreadMetadata(
-						messagesIds,
-						{
-							attachments: newAttachments,
-						},
-					)
 
-					if (appConfig.features.devMode) {
-						console.log('metadataUpdateResults', metadataUpdateResults)
+					// Log the payload bytes size
+					const payloadSize = new TextEncoder().encode(
+						JSON.stringify({ attachments: attachmentsToProcess, messagesIds }),
+					).length
+					console.log(
+						`Updating thread metadata with ${attachmentsToProcess.length} attachments, total payload size: ${payloadSize} bytes`,
+					)
+					const MAX_CHUNK_SIZE = 4e6 // 4MB in bytes
+
+					if (payloadSize > MAX_CHUNK_SIZE) {
+						console.warn(
+							`Payload size exceeds ${MAX_CHUNK_SIZE / 1e6}MB, splitting the update into smaller chunks`,
+						)
+						const chunks: FileAttachment[][] = []
+						let currentChunk: FileAttachment[] = []
+						let currentChunkSize = 0
+
+						for (const attachment of attachmentsToProcess) {
+							const attachmentSize = new TextEncoder().encode(
+								JSON.stringify(attachment),
+							).length
+							if (
+								currentChunkSize + attachmentSize > MAX_CHUNK_SIZE &&
+								currentChunk.length > 0
+							) {
+								chunks.push(currentChunk)
+								currentChunk = []
+								currentChunkSize = 0
+							}
+							currentChunk.push(attachment)
+							currentChunkSize += attachmentSize
+						}
+						if (currentChunk.length > 0) {
+							chunks.push(currentChunk)
+						}
+
+						const metadataUpdateResults = await Promise.allSettled(
+							chunks.map((chunk) =>
+								updateThreadMetadata(
+									chunk.flatMap((att) => (att as FileAttachment).messageIds),
+									{
+										attachments: chunk,
+									},
+								),
+							),
+						)
+						const failedChunks = metadataUpdateResults.filter(
+							(result) => result.status === 'rejected',
+						)
+						console.info(
+							failedChunks.length > 0
+								? 'Some chunks failed to update metadata:'
+								: 'All chunks updated metadata successfully  ——> chunk strategy.',
+							{
+								failedChunks,
+							},
+						)
+					} else {
+						const metadataUpdateResults = await updateThreadMetadata(
+							messagesIds,
+							{
+								attachments: attachmentsToProcess,
+							},
+						)
+						if (appConfig.features.devMode) {
+							console.log(
+								'metadataUpdateResults ——> no chunk strategy',
+								metadataUpdateResults,
+							)
+						}
 					}
+
 					// If new attachments are not equal from remote/local
 					if (!isEqual(attachments, newAttachments)) {
 						console.log(

--- a/apps/masterbots.ai/next.config.ts
+++ b/apps/masterbots.ai/next.config.ts
@@ -1,8 +1,8 @@
-/** @type {import('next').NextConfig} */
+import path from 'node:path'
+import { withSentryConfig } from '@sentry/nextjs'
+import type { NextConfig } from 'next'
 
-const path = require('node:path')
-
-module.exports = {
+const nextConfig: NextConfig = {
 	images: {
 		// ? Allowing SVGs to be used as images from trusted sources
 		dangerouslyAllowSVG: true,
@@ -98,10 +98,7 @@ module.exports = {
 }
 
 // Injected content via Sentry wizard below
-
-const { withSentryConfig } = require('@sentry/nextjs')
-
-module.exports = withSentryConfig(module.exports, {
+export default withSentryConfig(nextConfig, {
 	// For all available options, see:
 	// https://www.npmjs.com/package/@sentry/webpack-plugin#options
 

--- a/apps/masterbots.ai/package.json
+++ b/apps/masterbots.ai/package.json
@@ -73,6 +73,7 @@
 		"nextjs-toploader": "2.6.12",
 		"nodemailer": "^6.10.0",
 		"openai": "4.79.3",
+		"p-limit": "^6.2.0",
 		"react": "19.1.0",
 		"react-day-picker": "^8.10.1",
 		"react-dom": "19.1.0",

--- a/apps/masterbots.ai/vercel.json
+++ b/apps/masterbots.ai/vercel.json
@@ -7,6 +7,10 @@
 		{
 			"path": "/api/cron/delete-requested-accounts",
 			"schedule": "0 3 * * *"
+		},
+		{
+			"path": "/api/cron/refresh-attachment-links",
+			"schedule": "*/10 * * * *"
 		}
 	],
 	"redirects": [

--- a/bun.lock
+++ b/bun.lock
@@ -87,6 +87,7 @@
         "nextjs-toploader": "2.6.12",
         "nodemailer": "^6.10.0",
         "openai": "4.79.3",
+        "p-limit": "^6.2.0",
         "react": "19.1.0",
         "react-day-picker": "^8.10.1",
         "react-dom": "19.1.0",
@@ -2016,7 +2017,7 @@
 
     "own-keys": ["own-keys@1.0.1", "", { "dependencies": { "get-intrinsic": "^1.2.6", "object-keys": "^1.1.1", "safe-push-apply": "^1.0.0" } }, "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg=="],
 
-    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+    "p-limit": ["p-limit@6.2.0", "", { "dependencies": { "yocto-queue": "^1.1.1" } }, "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA=="],
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
@@ -2568,7 +2569,7 @@
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
-    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+    "yocto-queue": ["yocto-queue@1.2.1", "", {}, "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg=="],
 
     "yoga-wasm-web": ["yoga-wasm-web@0.3.3", "", {}, "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA=="],
 
@@ -2623,6 +2624,10 @@
     "@genql/cli/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
     "@genql/cli/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
+
+    "@google-cloud/storage/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "@graphql-tools/load/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -2762,6 +2767,8 @@
 
     "make-dir/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "masterbots.ai/@types/bun": ["@types/bun@1.2.17", "", { "dependencies": { "bun-types": "1.2.17" } }, "sha512-l/BYs/JYt+cXA/0+wUhulYJB6a6p//GTPiJ7nV+QHa8iiId4HZmnu/3J/SowP5g0rTiERY2kfGKXEK5Ehltx4Q=="],
+
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
     "mdast-util-mdx-jsx/parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
@@ -2779,6 +2786,8 @@
     "openid-client/jose": ["jose@4.15.9", "", {}, "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA=="],
 
     "openid-client/object-hash": ["object-hash@2.2.0", "", {}, "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="],
+
+    "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
@@ -2906,6 +2915,10 @@
 
     "@genql/cli/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
 
+    "@google-cloud/storage/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "@graphql-tools/load/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
     "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
     "@next/eslint-plugin-next/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
@@ -2968,6 +2981,8 @@
 
     "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
+    "masterbots.ai/@types/bun/bun-types": ["bun-types@1.2.17", "", { "dependencies": { "@types/node": "*" } }, "sha512-ElC7ItwT3SCQwYZDYoAH+q6KT4Fxjl8DtZ6qDulUFBmXA8YB4xo+l54J9ZJN+k2pphfn9vk7kfubeSd5QfTVJQ=="],
+
     "mdast-util-mdx-jsx/parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "mdast-util-mdx-jsx/parse-entities/character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
@@ -2981,6 +2996,8 @@
     "mdast-util-mdx-jsx/parse-entities/is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
 
     "openai/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "refractor/hastscript/@types/hast": ["@types/hast@2.3.10", "", { "dependencies": { "@types/unist": "^2" } }, "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw=="],
 
@@ -3031,8 +3048,6 @@
     "@commitlint/top-level/find-up/locate-path/p-locate/p-limit": ["p-limit@4.0.0", "", { "dependencies": { "yocto-queue": "^1.0.0" } }, "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ=="],
 
     "@genql/cli/yargs/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
-
-    "@commitlint/top-level/find-up/locate-path/p-locate/p-limit/yocto-queue": ["yocto-queue@1.2.1", "", {}, "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg=="],
 
     "@genql/cli/yargs/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
   }

--- a/packages/mb-drizzle/src/drizzle/relations.ts
+++ b/packages/mb-drizzle/src/drizzle/relations.ts
@@ -30,54 +30,6 @@ import {
 	userToken,
 } from './schema'
 
-export const chatbotRelations = relations(chatbot, ({ one, many }) => ({
-	complexityEnum: one(complexityEnum, {
-		fields: [chatbot.defaultComplexity],
-		references: [complexityEnum.value],
-	}),
-	lengthEnum: one(lengthEnum, {
-		fields: [chatbot.defaultLength],
-		references: [lengthEnum.value],
-	}),
-	toneEnum: one(toneEnum, {
-		fields: [chatbot.defaultTone],
-		references: [toneEnum.value],
-	}),
-	typeEnum: one(typeEnum, {
-		fields: [chatbot.defaultType],
-		references: [typeEnum.value],
-	}),
-	preferences: many(preference),
-	socialFollowings: many(socialFollowing),
-	chatbotCategories: many(chatbotCategory),
-	promptChatbots: many(promptChatbot),
-	chatbotDomains: many(chatbotDomain),
-	threads: many(thread),
-}))
-
-export const complexityEnumRelations = relations(
-	complexityEnum,
-	({ many }) => ({
-		chatbots: many(chatbot),
-		preferences: many(preference),
-	}),
-)
-
-export const lengthEnumRelations = relations(lengthEnum, ({ many }) => ({
-	chatbots: many(chatbot),
-	preferences: many(preference),
-}))
-
-export const toneEnumRelations = relations(toneEnum, ({ many }) => ({
-	chatbots: many(chatbot),
-	preferences: many(preference),
-}))
-
-export const typeEnumRelations = relations(typeEnum, ({ many }) => ({
-	chatbots: many(chatbot),
-	preferences: many(preference),
-}))
-
 export const promptRelations = relations(prompt, ({ one, many }) => ({
 	promptTypeEnum: one(promptTypeEnum, {
 		fields: [prompt.type],
@@ -119,6 +71,54 @@ export const preferenceRelations = relations(preference, ({ one }) => ({
 		fields: [preference.userId],
 		references: [user.userId],
 	}),
+}))
+
+export const chatbotRelations = relations(chatbot, ({ one, many }) => ({
+	preferences: many(preference),
+	complexityEnum: one(complexityEnum, {
+		fields: [chatbot.defaultComplexity],
+		references: [complexityEnum.value],
+	}),
+	lengthEnum: one(lengthEnum, {
+		fields: [chatbot.defaultLength],
+		references: [lengthEnum.value],
+	}),
+	toneEnum: one(toneEnum, {
+		fields: [chatbot.defaultTone],
+		references: [toneEnum.value],
+	}),
+	typeEnum: one(typeEnum, {
+		fields: [chatbot.defaultType],
+		references: [typeEnum.value],
+	}),
+	socialFollowings: many(socialFollowing),
+	chatbotCategories: many(chatbotCategory),
+	promptChatbots: many(promptChatbot),
+	chatbotDomains: many(chatbotDomain),
+	threads: many(thread),
+}))
+
+export const complexityEnumRelations = relations(
+	complexityEnum,
+	({ many }) => ({
+		preferences: many(preference),
+		chatbots: many(chatbot),
+	}),
+)
+
+export const lengthEnumRelations = relations(lengthEnum, ({ many }) => ({
+	preferences: many(preference),
+	chatbots: many(chatbot),
+}))
+
+export const toneEnumRelations = relations(toneEnum, ({ many }) => ({
+	preferences: many(preference),
+	chatbots: many(chatbot),
+}))
+
+export const typeEnumRelations = relations(typeEnum, ({ many }) => ({
+	preferences: many(preference),
+	chatbots: many(chatbot),
 }))
 
 export const userRelations = relations(user, ({ many }) => ({

--- a/packages/mb-drizzle/src/drizzle/schema.ts
+++ b/packages/mb-drizzle/src/drizzle/schema.ts
@@ -35,52 +35,6 @@ export const category = pgTable(
 	(table) => [unique('category_name_key').on(table.name)],
 )
 
-export const chatbot = pgTable(
-	'chatbot',
-	{
-		chatbotId: serial('chatbot_id').primaryKey().notNull(),
-		name: text().notNull(),
-		description: text(),
-		avatar: text(),
-		createdBy: text('created_by').notNull(),
-		defaultTone: text('default_tone'),
-		defaultLength: text('default_length'),
-		defaultType: text('default_type'),
-		defaultComplexity: text('default_complexity'),
-	},
-	(table) => [
-		foreignKey({
-			columns: [table.defaultComplexity],
-			foreignColumns: [complexityEnum.value],
-			name: 'chatbot_default_complexity_fkey',
-		})
-			.onUpdate('restrict')
-			.onDelete('restrict'),
-		foreignKey({
-			columns: [table.defaultLength],
-			foreignColumns: [lengthEnum.value],
-			name: 'chatbot_default_length_fkey',
-		})
-			.onUpdate('restrict')
-			.onDelete('restrict'),
-		foreignKey({
-			columns: [table.defaultTone],
-			foreignColumns: [toneEnum.value],
-			name: 'chatbot_default_tone_fkey',
-		})
-			.onUpdate('restrict')
-			.onDelete('restrict'),
-		foreignKey({
-			columns: [table.defaultType],
-			foreignColumns: [typeEnum.value],
-			name: 'chatbot_default_type_fkey',
-		})
-			.onUpdate('restrict')
-			.onDelete('restrict'),
-		unique('chatbot_name_key').on(table.name),
-	],
-)
-
 export const messageTypeEnum = pgTable('message_type_enum', {
 	value: text().primaryKey().notNull(),
 })
@@ -188,29 +142,6 @@ export const preference = pgTable(
 	],
 )
 
-export const referral = pgTable(
-	'referral',
-	{
-		referralCode: varchar('referral_code', { length: 6 })
-			.primaryKey()
-			.notNull(),
-		userId: uuid('user_id').notNull(),
-		referrerId: uuid('referrer_id').notNull(),
-	},
-	(table) => [
-		foreignKey({
-			columns: [table.userId],
-			foreignColumns: [user.userId],
-			name: 'referral_user_id_fkey',
-		}),
-		foreignKey({
-			columns: [table.referrerId],
-			foreignColumns: [user.userId],
-			name: 'referral_referrer_id_fkey',
-		}),
-	],
-)
-
 export const user = pgTable(
 	'user',
 	{
@@ -243,6 +174,7 @@ export const user = pgTable(
 			withTimezone: true,
 			mode: 'string',
 		}),
+		promoCode: text('promo_code'),
 	},
 	(table) => [
 		index('idx_users_role').using(
@@ -252,6 +184,29 @@ export const user = pgTable(
 		unique('user_username_key').on(table.username),
 		unique('user_email_key').on(table.email),
 		unique('unique_slug').on(table.slug),
+	],
+)
+
+export const referral = pgTable(
+	'referral',
+	{
+		referralCode: varchar('referral_code', { length: 6 })
+			.primaryKey()
+			.notNull(),
+		userId: uuid('user_id').notNull(),
+		referrerId: uuid('referrer_id').notNull(),
+	},
+	(table) => [
+		foreignKey({
+			columns: [table.userId],
+			foreignColumns: [user.userId],
+			name: 'referral_user_id_fkey',
+		}),
+		foreignKey({
+			columns: [table.referrerId],
+			foreignColumns: [user.userId],
+			name: 'referral_referrer_id_fkey',
+		}),
 	],
 )
 
@@ -267,6 +222,53 @@ export const modelsEnum = pgTable(
 			table.value.asc().nullsLast().op('text_ops'),
 		),
 		unique('models_enum_value_key').on(table.value),
+	],
+)
+
+export const chatbot = pgTable(
+	'chatbot',
+	{
+		chatbotId: serial('chatbot_id').primaryKey().notNull(),
+		name: text().notNull(),
+		description: text(),
+		avatar: text(),
+		createdBy: text('created_by').notNull(),
+		defaultTone: text('default_tone'),
+		defaultLength: text('default_length'),
+		defaultType: text('default_type'),
+		defaultComplexity: text('default_complexity'),
+		disabled: boolean().default(false),
+	},
+	(table) => [
+		foreignKey({
+			columns: [table.defaultComplexity],
+			foreignColumns: [complexityEnum.value],
+			name: 'chatbot_default_complexity_fkey',
+		})
+			.onUpdate('restrict')
+			.onDelete('restrict'),
+		foreignKey({
+			columns: [table.defaultLength],
+			foreignColumns: [lengthEnum.value],
+			name: 'chatbot_default_length_fkey',
+		})
+			.onUpdate('restrict')
+			.onDelete('restrict'),
+		foreignKey({
+			columns: [table.defaultTone],
+			foreignColumns: [toneEnum.value],
+			name: 'chatbot_default_tone_fkey',
+		})
+			.onUpdate('restrict')
+			.onDelete('restrict'),
+		foreignKey({
+			columns: [table.defaultType],
+			foreignColumns: [typeEnum.value],
+			name: 'chatbot_default_type_fkey',
+		})
+			.onUpdate('restrict')
+			.onDelete('restrict'),
+		unique('chatbot_name_key').on(table.name),
 	],
 )
 
@@ -596,14 +598,14 @@ export const thread = pgTable(
 		chatbotId: integer('chatbot_id').notNull(),
 		threadId: uuid('thread_id').defaultRandom().notNull(),
 		userId: uuid('user_id'),
-		isPublic: boolean('is_public').default(true),
+		isPublic: boolean('is_public').default(false),
 		model: varchar({ length: 30 }).default('openAi').notNull(),
 		isApproved: boolean('is_approved').default(false),
 		isBlocked: boolean('is_blocked').default(false),
 		parentThreadId: uuid('parent_thread_id'),
 		slug: text().notNull(),
 		shortLink: text('short_link'),
-		metadata: jsonb(),
+		metadata: jsonb('metadata').default(null),
 	},
 	(table) => [
 		foreignKey({


### PR DESCRIPTION
## Summary by Sourcery

Introduce a cron job and HTTP endpoint to refresh expiring file attachment links, and improve related schema, hooks, and metadata update logic.

New Features:
- Add a cron job and API route to refresh expiring attachment signed URLs using Google Cloud Storage

Enhancements:
- Enhance useIndexedDB hook to log payload sizes, split large metadata updates into 4MB chunks, and handle chunked updates
- Improve BrowseList search: debounce with a timeout ref, merge paginated results via uniqBy, and cleanup on unmount
- Refactor updateThreadMetadata action to fetch and merge existing attachments per thread and de-duplicate entries
- Convert Next.js config to TypeScript and export maxDuration for image generation route
- Extend image generation timeout to 2 minutes
- Include loadingState in useFileAttachments hook dependency and guard
- Toggle Sentry debug mode based on environment

Build:
- Add p-limit dependency for concurrency control