### PR TITLE
fix: persistent route

### DIFF
--- a/apps/masterbots.ai/components/layout/header/header.tsx
+++ b/apps/masterbots.ai/components/layout/header/header.tsx
@@ -100,33 +100,6 @@ export function Header() {
 	const publicUrl = buildUrlWithCurrentContext('/')
 	const personalUrl = buildUrlWithCurrentContext('/c')
 
-	// TODO: Reconsider the logic below for the URLs
-	// if (activeCategory && activeChatbot?.categories[0]?.category?.name) {
-	//   publicUrl = urlBuilders.topicThreadListUrl({
-	//     type: 'public',
-	//     category: activeChatbot?.categories[0].category.name,
-	//   })
-	//   personalUrl = urlBuilders.topicThreadListUrl({
-	//     type: 'personal',
-	//     category: activeChatbot?.categories[0].category.name,
-	//   })
-	// }
-
-	// if (activeChatbot?.name) {
-	//   publicUrl = urlBuilders.chatbotThreadListUrl({
-	//     type: 'public',
-	//     chatbot: activeChatbot?.name || '',
-	//     domain: canonicalDomain || 'prompt',
-	//     category: activeChatbot?.categories[0]?.category?.name || '',
-	//   })
-	//   personalUrl = urlBuilders.chatbotThreadListUrl({
-	//     type: 'personal',
-	//     chatbot: activeChatbot?.name || '',
-	//     domain: canonicalDomain || 'prompt',
-	//     category: activeChatbot?.categories[0]?.category?.name || '',
-	//   })
-	// }
-
 	const pathname = usePathname()
 	const routeType = getRouteType(pathname)
 

--- a/apps/masterbots.ai/components/layout/header/header.tsx
+++ b/apps/masterbots.ai/components/layout/header/header.tsx
@@ -12,6 +12,7 @@ import { useSidebar } from '@/lib/hooks/use-sidebar'
 import { getCanonicalDomain } from '@/lib/url'
 import { cn, getRouteColor, getRouteType } from '@/lib/utils'
 import { appConfig } from 'mb-env'
+import { toSlug } from 'mb-lib'
 
 function HeaderLink({
 	href,
@@ -72,8 +73,32 @@ export function Header() {
 		setActiveChatbot(null)
 	}
 
-	const publicUrl = '/'
-	const personalUrl = '/c'
+	const preserveContextNavigation = (e: React.MouseEvent) => {
+		//! The URL will be built with the current context
+	}
+
+	//? Build URLs that preserve the current category and chatbot
+	const buildUrlWithCurrentContext = (baseUrl: string) => {
+		if (activeCategory && activeChatbot?.categories[0]?.category?.name) {
+			const categoryName = activeChatbot.categories[0].category.name
+			const chatbotName = activeChatbot.name
+			const domain = canonicalDomain || 'prompt'
+
+			//? Build the full URL
+			const path = `/${toSlug(categoryName)}/${domain}/${toSlug(chatbotName)}`
+			return baseUrl === '/' ? path : `${baseUrl}${path}`
+		}
+		if (activeCategory) {
+			//? Build category URL only
+			const categoryName = activeChatbot?.categories[0]?.category?.name || 'ai'
+			const path = `/${toSlug(categoryName)}`
+			return baseUrl === '/' ? path : `${baseUrl}${path}`
+		}
+		return baseUrl
+	}
+
+	const publicUrl = buildUrlWithCurrentContext('/')
+	const personalUrl = buildUrlWithCurrentContext('/c')
 
 	// TODO: Reconsider the logic below for the URLs
 	// if (activeCategory && activeChatbot?.categories[0]?.category?.name) {
@@ -106,7 +131,7 @@ export function Header() {
 	const routeType = getRouteType(pathname)
 
 	return (
-		<header className="sticky top-0 z-50 flex items-center justify-between w-full h-16 px-4 border-b shrink-0 bg-gradient-to-b from-background/10 via-background/50 to-background/80 backdrop-blur-xl">
+		<header className="flex sticky top-0 z-50 justify-between items-center px-4 w-full h-16 bg-gradient-to-b border-b backdrop-blur-xl shrink-0 from-background/10 via-background/50 to-background/80">
 			<div className="flex items-center">
 				<React.Suspense fallback={null}>
 					<SidebarToggle />
@@ -123,7 +148,7 @@ export function Header() {
 				<div className="flex items-center gap-1 ml-2.5">
 					<HeaderLink
 						href={personalUrl}
-						onClick={resetNavigation}
+						onClick={preserveContextNavigation}
 						text="Chat"
 						className={cn({
 							'hidden sm:flex': routeType !== 'chat',
@@ -131,7 +156,7 @@ export function Header() {
 					/>
 					<HeaderLink
 						href={publicUrl}
-						onClick={resetNavigation}
+						onClick={preserveContextNavigation}
 						text="Public"
 						className={cn({
 							'hidden sm:flex': routeType !== 'public',
@@ -150,7 +175,7 @@ export function Header() {
 				</div>
 			</div>
 			<div className="flex items-center space-x-4">
-				<React.Suspense fallback={<div className="flex-1 overflow-auto" />}>
+				<React.Suspense fallback={<div className="overflow-auto flex-1" />}>
 					<UserLogin />
 				</React.Suspense>
 			</div>

--- a/apps/masterbots.ai/components/layout/sidebar/sidebar.tsx
+++ b/apps/masterbots.ai/components/layout/sidebar/sidebar.tsx
@@ -26,6 +26,7 @@ export function Sidebar({
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
 	React.useEffect(() => {
+		// Only reset state when going to root /c route
 		if (rootAndChatRegex.test(pathname)) {
 			resetState()
 		}

--- a/apps/masterbots.ai/lib/hooks/use-sidebar.tsx
+++ b/apps/masterbots.ai/lib/hooks/use-sidebar.tsx
@@ -10,6 +10,8 @@ import * as React from 'react'
 import { useAsync } from 'react-use'
 
 const LOCAL_STORAGE_KEY = 'sidebar'
+const SELECTED_CATEGORIES_KEY = 'selectedCategories'
+const SELECTED_CHATBOTS_KEY = 'selectedChatbots'
 
 export interface NavigationParams {
 	page: string | undefined
@@ -75,9 +77,23 @@ type NavigateToParams<
 
 export function SidebarProvider({ children }: SidebarProviderProps) {
 	const [selectedCategories, setSelectedCategories] = React.useState<number[]>(
-		[],
+		() => {
+			if (typeof window !== 'undefined') {
+				const stored = localStorage.getItem(SELECTED_CATEGORIES_KEY)
+				return stored ? JSON.parse(stored) : []
+			}
+			return []
+		},
 	)
-	const [selectedChatbots, setSelectedChatbots] = React.useState<number[]>([])
+	const [selectedChatbots, setSelectedChatbots] = React.useState<number[]>(
+		() => {
+			if (typeof window !== 'undefined') {
+				const stored = localStorage.getItem(SELECTED_CHATBOTS_KEY)
+				return stored ? JSON.parse(stored) : []
+			}
+			return []
+		},
+	)
 	const { data: session } = useSession()
 	const { userSlug } = useParams()
 	const pathname = usePathname()
@@ -106,23 +122,15 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
 				category.chatbots.map((chatbot) => chatbot.chatbotId),
 			),
 		}
-		const pathParts = pathname.split('/')
-		const prevPathParts = (prevPath.current || '').split('/')
 
-		if (
-			(prevPath.current !== pathname &&
-				pathParts[1] !== prevPathParts[1] &&
-				pathParts[1] === 'c') ||
-			(selectedCategories.length === 0 && selectedChatbots.length === 0)
-		) {
+		// Initialize with all categories and chatbots selected if no selections exist
+		if (selectedCategories.length === 0 && selectedChatbots.length === 0) {
 			setSelectedCategories(categoriesObj.categoriesId)
 			setSelectedChatbots(categoriesObj.chatbotsId)
 		}
 
-		prevPath.current = pathname
-
 		return categoriesObj
-	}, [pathname, prevPath.current, userSlug])
+	}, [pathname, userSlug])
 
 	const [isSidebarOpen, setSidebarOpen] = React.useState(false)
 	const [isLoading, setLoading] = React.useState(true)
@@ -145,6 +153,26 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
 		}
 		setLoading(false)
 	}, [])
+
+	//? Persist selected categories to localStorage
+	React.useEffect(() => {
+		if (selectedCategories.length > 0) {
+			localStorage.setItem(
+				SELECTED_CATEGORIES_KEY,
+				JSON.stringify(selectedCategories),
+			)
+		}
+	}, [selectedCategories])
+
+	//? Persist selected chatbots to localStorage
+	React.useEffect(() => {
+		if (selectedChatbots.length > 0) {
+			localStorage.setItem(
+				SELECTED_CHATBOTS_KEY,
+				JSON.stringify(selectedChatbots),
+			)
+		}
+	}, [selectedChatbots])
 
 	const toggleSidebar = (toggle = true) => {
 		setSidebarOpen((value) => {
@@ -174,9 +202,18 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
 				toSlug(cat.name) === personalProfilesTopicSlugOrDomainSlug ||
 				toSlug(cat.name) === publicTopicSlugOrBasePath,
 		)
+
 		if (category) {
 			setActiveCategory(category.categoryId)
 			setExpandedCategories([category.categoryId])
+
+			//? Set selected categories based on URL - ensure the current category is selected
+			setSelectedCategories((prev) => {
+				if (!prev.includes(category.categoryId)) {
+					return [...prev, category.categoryId]
+				}
+				return prev
+			})
 
 			if (
 				domainSlugOrPublicChatbotSlug ||
@@ -192,12 +229,23 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
 				)
 				if (chatbot) {
 					setActiveChatbot(chatbot.chatbot)
+					//? Set selected chatbots based on URL - ensure the current chatbot is selected
+					setSelectedChatbots((prev) => {
+						if (!prev.includes(chatbot.chatbot.chatbotId)) {
+							return [...prev, chatbot.chatbot.chatbotId]
+						}
+						return prev
+					})
 				} else {
 					setActiveChatbot(null)
 				}
 			} else {
 				setActiveChatbot(null)
 			}
+		} else {
+			setActiveCategory(null)
+			setActiveChatbot(null)
+			setExpandedCategories([])
 		}
 	}, [pathname, categories])
 


### PR DESCRIPTION
## Summary by Sourcery

Add persistent sidebar selections using localStorage and enhance navigation to preserve selected category and chatbot context across routes.

New Features:
- Persist selected categories and chatbots in localStorage to survive page reloads and sessions.
- Build header navigation URLs that maintain the current category and chatbot context.

Enhancements:
- Initialize sidebar state from localStorage and auto-select all items when no prior selection exists.
- Simplify sidebar hook by removing outdated path-based reset logic and only resetting state on the root route.
- Minor CSS class reordering in header and replace direct reset with context-preserving click handler in navigation links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation links in the header now preserve your current category and chatbot context when switching between "Chat" and "Public" sections.
  * Your selected categories and chatbots in the sidebar are now saved and restored across sessions for a more consistent experience.

* **Documentation**
  * Added comments to clarify sidebar behavior for improved code readability.

* **Style**
  * Minor reordering of CSS classes in the header for improved structure (no visual changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->