### PR TITLE
Revert "fix: persistent route"

### DIFF
--- a/apps/masterbots.ai/components/layout/header/header.tsx
+++ b/apps/masterbots.ai/components/layout/header/header.tsx
@@ -12,7 +12,6 @@ import { useSidebar } from '@/lib/hooks/use-sidebar'
 import { getCanonicalDomain } from '@/lib/url'
 import { cn, getRouteColor, getRouteType } from '@/lib/utils'
 import { appConfig } from 'mb-env'
-import { toSlug } from 'mb-lib'
 
 function HeaderLink({
 	href,
@@ -73,38 +72,41 @@ export function Header() {
 		setActiveChatbot(null)
 	}
 
-	const preserveContextNavigation = (e: React.MouseEvent) => {
-		//! The URL will be built with the current context
-	}
+	const publicUrl = '/'
+	const personalUrl = '/c'
 
-	//? Build URLs that preserve the current category and chatbot
-	const buildUrlWithCurrentContext = (baseUrl: string) => {
-		if (activeCategory && activeChatbot?.categories[0]?.category?.name) {
-			const categoryName = activeChatbot.categories[0].category.name
-			const chatbotName = activeChatbot.name
-			const domain = canonicalDomain || 'prompt'
+	// TODO: Reconsider the logic below for the URLs
+	// if (activeCategory && activeChatbot?.categories[0]?.category?.name) {
+	//   publicUrl = urlBuilders.topicThreadListUrl({
+	//     type: 'public',
+	//     category: activeChatbot?.categories[0].category.name,
+	//   })
+	//   personalUrl = urlBuilders.topicThreadListUrl({
+	//     type: 'personal',
+	//     category: activeChatbot?.categories[0].category.name,
+	//   })
+	// }
 
-			//? Build the full URL
-			const path = `/${toSlug(categoryName)}/${domain}/${toSlug(chatbotName)}`
-			return baseUrl === '/' ? path : `${baseUrl}${path}`
-		}
-		if (activeCategory) {
-			//? Build category URL only
-			const categoryName = activeChatbot?.categories[0]?.category?.name || 'ai'
-			const path = `/${toSlug(categoryName)}`
-			return baseUrl === '/' ? path : `${baseUrl}${path}`
-		}
-		return baseUrl
-	}
-
-	const publicUrl = buildUrlWithCurrentContext('/')
-	const personalUrl = buildUrlWithCurrentContext('/c')
+	// if (activeChatbot?.name) {
+	//   publicUrl = urlBuilders.chatbotThreadListUrl({
+	//     type: 'public',
+	//     chatbot: activeChatbot?.name || '',
+	//     domain: canonicalDomain || 'prompt',
+	//     category: activeChatbot?.categories[0]?.category?.name || '',
+	//   })
+	//   personalUrl = urlBuilders.chatbotThreadListUrl({
+	//     type: 'personal',
+	//     chatbot: activeChatbot?.name || '',
+	//     domain: canonicalDomain || 'prompt',
+	//     category: activeChatbot?.categories[0]?.category?.name || '',
+	//   })
+	// }
 
 	const pathname = usePathname()
 	const routeType = getRouteType(pathname)
 
 	return (
-		<header className="flex sticky top-0 z-50 justify-between items-center px-4 w-full h-16 bg-gradient-to-b border-b backdrop-blur-xl shrink-0 from-background/10 via-background/50 to-background/80">
+		<header className="sticky top-0 z-50 flex items-center justify-between w-full h-16 px-4 border-b shrink-0 bg-gradient-to-b from-background/10 via-background/50 to-background/80 backdrop-blur-xl">
 			<div className="flex items-center">
 				<React.Suspense fallback={null}>
 					<SidebarToggle />
@@ -121,7 +123,7 @@ export function Header() {
 				<div className="flex items-center gap-1 ml-2.5">
 					<HeaderLink
 						href={personalUrl}
-						onClick={preserveContextNavigation}
+						onClick={resetNavigation}
 						text="Chat"
 						className={cn({
 							'hidden sm:flex': routeType !== 'chat',
@@ -129,7 +131,7 @@ export function Header() {
 					/>
 					<HeaderLink
 						href={publicUrl}
-						onClick={preserveContextNavigation}
+						onClick={resetNavigation}
 						text="Public"
 						className={cn({
 							'hidden sm:flex': routeType !== 'public',
@@ -148,7 +150,7 @@ export function Header() {
 				</div>
 			</div>
 			<div className="flex items-center space-x-4">
-				<React.Suspense fallback={<div className="overflow-auto flex-1" />}>
+				<React.Suspense fallback={<div className="flex-1 overflow-auto" />}>
 					<UserLogin />
 				</React.Suspense>
 			</div>

--- a/apps/masterbots.ai/components/layout/sidebar/sidebar.tsx
+++ b/apps/masterbots.ai/components/layout/sidebar/sidebar.tsx
@@ -27,7 +27,6 @@ export function Sidebar({
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
 	React.useEffect(() => {
-		// Only reset state when going to root /c route
 		if (rootAndChatRegex.test(pathname)) {
 			resetState()
 		}


### PR DESCRIPTION
Reverts bitcashorg/masterbots#529

> ⚠️ **NOTE:** I had to revert the PR due to several issues presenting while navigating:
> 1. When click to a category from chat and going to public rewrites the pathname.
> 2. When on a chatbot and I have a selected thread and I go to chat, I can see the user thread. [This is probably coming from before, but better to check it out at this list]
> 3. If I click again the public or chat link and I am in the same page (chat or public, depending the scenario) it doesn't take me back to home but instead I have to close the category to make that happen.
> 4. Duplicates the `c/` in the pathname when moving around active threads and between chat and public.

### Issues DEMO:


https://github.com/user-attachments/assets/e3e140b0-e52b-431e-ac7a-e4657ac97ff5


https://github.com/user-attachments/assets/a24e6336-febd-4bb5-a6e3-b456e67ae54f

 💡 Keep in mind to use the `urlBuilder` helper function, it tackles all routing scenarios.

## Summary by Sourcery

Revert the previous persistent route implementation to restore original navigation and sidebar behavior

Bug Fixes:
- Undo persistent category/chatbot selection to resolve navigation issues when switching between chat and public views

Enhancements:
- Simplify header links to use static '/' and '/c' URLs and reset navigation context on click
- Streamline sidebar selection logic by removing localStorage persistence and resetting state on relevant path changes

Chores:
- Remove unused url-building utilities and context-preservation code
- Revert commented-out placeholders and cleanup related routing logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Navigation links in the header now use static URLs and reset the active category and chatbot state when clicked, improving navigation consistency.
  * Sidebar state logic is simplified, with minor clean-up of comments and formatting.

* **Refactor**
  * Removed localStorage persistence for selected categories and chatbots, resulting in selections resetting when the page reloads or the path changes.
  * Streamlined sidebar and header logic for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->