### PR TITLE
Fix: Thread Questions's slug (Chat & Bot)

### DIFF
--- a/apps/web/lib/hooks/use-sidebar.tsx
+++ b/apps/web/lib/hooks/use-sidebar.tsx
@@ -321,7 +321,6 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
 		setTab(cate)
 	}
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
 	const filteredCategories = React.useMemo(() => {
 		const categoriesChatbots = categories?.categoriesChatbots || []
 

--- a/apps/web/lib/url.ts
+++ b/apps/web/lib/url.ts
@@ -277,7 +277,11 @@ export const urlBuilders = {
 		raw = false,
 	}: ThreadUrlParams): string {
 		try {
-			if (!category || !chatbot || !threadSlug || !domain) {
+			if (
+				!chatbot ||
+				!threadSlug ||
+				(type !== 'bot' && (!domain || !category))
+			) {
 				const threadUrlEntries = { category, chatbot, domain, threadSlug }
 				const missing = Object.entries(threadUrlEntries)
 					.filter(([_, value]) => !value)
@@ -302,6 +306,9 @@ export const urlBuilders = {
 				case 'pro':
 					basePath = 'pro'
 					break
+				case 'bot':
+					basePath = 'b'
+					break
 				default:
 					if (appConfig.features.devMode)
 						console.error('Invalid thread URL type:', type)
@@ -318,7 +325,10 @@ export const urlBuilders = {
 				threadSlug,
 			)
 
-			console.log('threadUrl function called with parameters:', pathParts)
+			if (type === 'bot') {
+				pathParts.splice(2, 2)
+			}
+
 			return pathParts.join('/')
 		} catch (error) {
 			if (appConfig.features.devMode)

--- a/apps/web/lib/url.ts
+++ b/apps/web/lib/url.ts
@@ -310,12 +310,15 @@ export const urlBuilders = {
 
 			// Return the URL with the thread slug
 			const pathParts = basePath ? ['', basePath] : ['']
+
 			pathParts.push(
 				normalizeCategorySlug(category),
 				normalizeDomainSlug(domain, raw),
 				chatbot.toLowerCase(),
 				threadSlug,
 			)
+
+			console.log('threadUrl function called with parameters:', pathParts)
 			return pathParts.join('/')
 		} catch (error) {
 			if (appConfig.features.devMode)
@@ -412,6 +415,11 @@ export const urlBuilders = {
 				threadSlug,
 				threadQuestionSlug,
 			)
+			console.log({
+				'reach here for pathParts': {
+					pathParts,
+				},
+			})
 			return pathParts.join('/')
 		} catch (error) {
 			if (appConfig.features.devMode)
@@ -874,6 +882,11 @@ export function parsePath(pathname: string): PathParams {
 	const segments = pathname.split('/').filter(Boolean)
 	const isProfileThread = segments[0] === 'u' && segments[2] === 't'
 	const isBotProfile = segments[0] === 'b'
+	const isChatPage = segments[0] === 'c'
+
+	if (isChatPage) {
+		segments.shift()
+	}
 
 	if (isBotProfile) {
 		return {


### PR DESCRIPTION
## Summary by Sourcery

Refine URL building and parsing logic to correctly handle bot thread slugs and chat page prefixes, and clean up debug and lint code

Bug Fixes:
- Fix thread URL slug generation for bot threads by making domain and category optional, adding a 'b' base path, and trimming URL segments accordingly

Enhancements:
- Enhance path parsing to support chat pages prefixed with 'c' by stripping the prefix before routing

Chores:
- Add console.log for debugging thread pathParts and remove an obsolete lint-disable comment in the sidebar hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced shorter, cleaner URLs for bot threads (no domain/category required), making sharing and navigation easier.
- Bug Fixes
  - Improved recognition and normalization of chat page URLs to ensure consistent routing.
- Chores
  - Removed redundant lint-ignore annotations in a sidebar hook to keep the codebase clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->